### PR TITLE
Update SAMD to include latest boards, some fixes

### DIFF
--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -3170,6 +3170,75 @@
               "version": "9.4.0"
             }
           ]
+        },
+        {
+          "name": "Adafruit SAMD Boards",
+          "architecture": "samd",
+          "version": "1.3.0",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-samd-1.3.0.tar.bz2",
+          "archiveFileName": "adafruit-samd-1.3.0.tar.bz2",
+          "checksum": "SHA-256:98063fd43b1cdefb685ca1a98217fb722e7f0927c2a177e013dfcac874ac0ac8",
+          "size": "10469571",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather M0"
+            },
+            {
+              "name": "Adafruit Feather M0 Express"
+            },
+            {
+              "name": "Adafruit Metro M0 Express"
+            },
+            {
+              "name": "Adafruit Circuit Playground Express"
+            },
+            {
+              "name": "Adafruit Gemma M0"
+            },
+            {
+              "name": "Adafruit Trinket M0"
+            },
+            {
+              "name": "Adafruit ItsyBitsy M0"
+            },
+            {
+              "name": "Adafruit pIRkey M0"
+            },
+            {
+              "name": "Adafruit Metro M4"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "arm-none-eabi-gcc",
+              "version": "4.8.3-2014q1"
+            },
+            {
+              "packager": "arduino",
+              "name": "bossac",
+              "version": "1.8.0-48-gb176eee"
+            },
+            {
+              "packager": "arduino",
+              "name": "openocd",
+              "version": "0.9.0-arduino"
+            },
+            {
+              "packager": "arduino",
+              "name": "CMSIS",
+              "version": "4.5.0"
+            },
+            {
+              "packager": "arduino",
+              "name": "CMSIS-Atmel",
+              "version": "1.2.0"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Add grand central, pyportal, pybadge, jlink definition fixes, remove -erase from bossac (not needed!), deleted some old bossac execs

Thanks to @FHeilmann @caternuson @westfw @superduty and any other people who've fixed bugs & filed issues!