### PR TITLE
add workflow that trigger libraries rebuild

### DIFF
--- a/.github/workflows/trigger_libraries.yml
+++ b/.github/workflows/trigger_libraries.yml
@@ -1,0 +1,24 @@
+name: Trigger Libraries
+
+on:
+  push:
+    branches: gh-pages
+    paths: 'package_adafruit_index.json'
+
+jobs:
+  trigger-libraries:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Trigger Script
+      env:
+        GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
+      run: python3 examples/trigger_libraries.py
+

--- a/examples/trigger_libraries.py
+++ b/examples/trigger_libraries.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+import sys
+import subprocess
+import time
+
+all_libs = [
+    'Adafruit_TinyUSB_Arduino',
+    'Adafruit_SPIFlash',
+]
+
+GH_REPO_TOKEN = os.environ["GH_REPO_TOKEN"]
+
+gh_request = 'curl -X POST -H "Authorization: token {}"'.format(GH_REPO_TOKEN) + \
+             ' -H "Accept: application/vnd.github.everest-preview+json"' + \
+             ' -H "Content-Type: application/json"' + \
+             ' --data \'{"event_type": "rebuild"}\' '
+
+url = 'https://api.github.com/repos/adafruit/{}/dispatches'
+
+for lib in all_libs:
+    subprocess.run(gh_request + url.format(lib), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/examples/trigger_libraries.py
+++ b/examples/trigger_libraries.py
@@ -4,9 +4,35 @@ import sys
 import subprocess
 import time
 
+# sorted alphabetically
 all_libs = [
-    'Adafruit_TinyUSB_Arduino',
+    'Adafruit_9DOF',
+    'Adafruit_ADXL343',
+    'Adafruit_Arcada',
+    'Adafruit_BME280_Library',
+    'Adafruit_BMP280_Library',
+    'Adafruit_BusIO',
+    'Adafruit_EPD',
+    'Adafruit-GFX-Library',
+    'Adafruit_ICM20649',
+    'Adafruit_ILI9341',
+    'Adafruit_ImageReader',
+    'Adafruit_INA260',
+    'Adafruit_LIS2MDL',
+    'Adafruit_LIS3MDL',
+    'Adafruit_LSM303_Accel',
+    'Adafruit_LSM303DLH_Mag',
+    'Adafruit_LSM6DS',
+    'Adafruit_MAX31865',
+    'Adafruit_MCP4728',
+    'Adafruit_MLX90640',
+    'Adafruit_MSA301',
+    'Adafruit_NeoPixel_ZeroDMA',
+    'Adafruit_Sensor',
+    'Adafruit_SensorLab',
     'Adafruit_SPIFlash',
+    'Adafruit-ST7735-Library',
+    'Adafruit_TinyUSB_Arduino',
 ]
 
 GH_REPO_TOKEN = os.environ["GH_REPO_TOKEN"]


### PR DESCRIPTION
 when package_adafruit_index.json is changed on gh-pages branch. This require libraries repo to build on `repository_dispatch` event e.g
https://github.com/adafruit/Adafruit_TinyUSB_Arduino/blob/master/.github/workflows/githubci.yml#L3
