### PR TITLE
release nrf52 0.18.5

### DIFF
--- a/bpt.ini
+++ b/bpt.ini
@@ -257,7 +257,7 @@ index_template =
            "name":"Adafruit Feather nRF52840 Express"
         }},
         {{
-           "name":"Adafruit Feather Bluefruit Sense"
+           "name":"Adafruit Feather nRF52840 Sense"
         }},
         {{
            "name":"Adafruit Circuit Playground Bluefruit"

--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -5058,6 +5058,54 @@
               "version": "9.4.0"
             }
           ]
+        },
+        {
+          "name": "Adafruit nRF52",
+          "architecture": "nrf52",
+          "version": "0.18.5",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-nrf52-0.18.5.tar.bz2",
+          "archiveFileName": "adafruit-nrf52-0.18.5.tar.bz2",
+          "checksum": "SHA-256:b53377374c03feb7a5295beaa450235d09c2818dadaff5d6020a762f1fbd70b1",
+          "size": "18555924",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather nRF52832"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Express"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Sense"
+            },
+            {
+              "name": "Adafruit Circuit Playground Bluefruit"
+            },
+            {
+              "name": "Adafruit Metro nRF52840 Express"
+            },
+            {
+              "name": "Adafruit ItsyBitsy nRF52840"
+            },
+            {
+              "name": "Adafruit CLUE"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "arm-none-eabi-gcc",
+              "version": "7-2017q4"
+            },
+            {
+              "packager": "adafruit",
+              "name": "nrfjprog",
+              "version": "9.4.0"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
- Add macro `SPI_32MHZ_INTERFACE` to variant to select SPI or SPI1 to use 32mhz SPIM3
- Add PIN_BUZZER to variants with built-in speaker
- Enhance Particle Xenon support, PR #435 thanks to @outlandnish and @jaswope
- Rename cplay_ble.ino to bluefruit_playground.ino
- Use USB_PRODUCT string for default bledis model
- Increase attr table size for 840 to from 0xC00 to 0x1000
- Add more Adafruit sensor service: Gyro, Magento, Humid, Baro
- Upadte `image_upload.ino` to support CLUE with built-in TFT