### PR TITLE
Remove unnecessary installation of arduino:samd from CI workflow

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -36,7 +36,6 @@ jobs:
         arduino-cli config init
         arduino-cli core update-index
         arduino-cli core update-index --additional-urls $BSP_URL   
-        arduino-cli core install arduino:samd --additional-urls $BSP_URL
         arduino-cli core install adafruit:samd --additional-urls $BSP_URL
         arduino-cli core install arduino:avr --additional-urls $BSP_URL
         arduino-cli core install adafruit:avr --additional-urls $BSP_URL


### PR DESCRIPTION
Installing Arduino SAMD Boards is unnecessary and can mask issues caused by the Adafruit SAMD Boards platform.txt specifying different tools versions than what the package index's `toolsDependencies` field defines (e.g., https://github.com/adafruit/arduino-board-index/issues/22, https://github.com/adafruit/arduino-board-index/issues/47).