### PR TITLE
release Nrf52 0.20.5

### DIFF
--- a/bpt.ini
+++ b/bpt.ini
@@ -279,9 +279,9 @@ index_template =
      ],
      "toolsDependencies": [
        {{
-         "packager": "arduino",
+         "packager": "adafruit",
          "name": "arm-none-eabi-gcc",
-         "version": "7-2017q4"
+         "version": "9-2019q4"
        }},
        {{
          "packager": "adafruit",

--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -4,6 +4,54 @@
       "websiteURL": "https://adafruit.com",
       "tools": [
         {
+          "name": "arm-none-eabi-gcc",
+          "version": "9-2019q4",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
+              "checksum": "SHA-256:34180943d95f759c66444a40b032f7dd9159a562670fc334f049567de140c51b",
+              "size": "96613739"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2",
+              "checksum": "MD5:0dfa059aae18fcf7d842e30c525076a4",
+              "size": "128670769"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/gcc-arm-none-eabi-9-2019-q4-major-win32.zip",
+              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-win32.zip",
+              "checksum": "MD5:9d60cbb0e358ab6a9d3c9e5dc3624dd2",
+              "size": "153520070"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2",
+              "checksum": "MD5:241b64f0578db2cf146034fc5bcee3d4",
+              "size": "116770520"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2",
+              "checksum": "MD5:fe0029de4f4ec43cf7008944e34ff8cc",
+              "size": "116802378"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
+              "checksum": "SHA-256:090a0bc2b1956bc49392dff924a6c30fa57c88130097b1972204d67a45ce3cf3",
+              "size": "97427309"
+            }
+          ]
+        },
+        {
           "systems": [
             {
               "host": "i386-apple-darwin11",
@@ -5672,6 +5720,54 @@
               "packager": "arduino",
               "name": "arduinoOTA",
               "version": "1.2.1"
+            }
+          ]
+        },
+        {
+          "name": "Adafruit nRF52",
+          "architecture": "nrf52",
+          "version": "0.20.5",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-nrf52-0.20.5.tar.bz2",
+          "archiveFileName": "adafruit-nrf52-0.20.5.tar.bz2",
+          "checksum": "SHA-256:7e99232e5e580fe6200d3e6de687edbd2c757aeb80f31a9cca40a33f0f2b4ba9",
+          "size": "19073000",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather nRF52832"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Express"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Sense"
+            },
+            {
+              "name": "Adafruit Circuit Playground Bluefruit"
+            },
+            {
+              "name": "Adafruit Metro nRF52840 Express"
+            },
+            {
+              "name": "Adafruit ItsyBitsy nRF52840"
+            },
+            {
+              "name": "Adafruit CLUE"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "adafruit",
+              "name": "arm-none-eabi-gcc",
+              "version": "9-2019q4"
+            },
+            {
+              "packager": "adafruit",
+              "name": "nrfjprog",
+              "version": "9.4.0"
             }
           ]
         }

--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -5730,8 +5730,8 @@
           "category": "Adafruit",
           "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-nrf52-0.20.5.tar.bz2",
           "archiveFileName": "adafruit-nrf52-0.20.5.tar.bz2",
-          "checksum": "SHA-256:7e99232e5e580fe6200d3e6de687edbd2c757aeb80f31a9cca40a33f0f2b4ba9",
-          "size": "19073000",
+          "checksum": "SHA-256:71f998d7b3a3594d26980896dc75881666a64b876c319c555083a58e35c4e341",
+          "size": "19169093",
           "help": {
             "online": "https://forums.adafruit.com"
           },


### PR DESCRIPTION
- Update CMSIS from v4 to v5 to fix build with Tensorflow
- Update gcc toolchain from gcc 7-2017q4 to 9-2019q4. This has been tested on Windows, Ubuntu and macOS. Except for windows need to be packaged and download from this https://github.com/adafruit/arduino-board-index/releases/tag/build-tools (due to Arduino expected folder structure). Other platform use the directly from official ARM website, platform that is not available from ARM use the previous gcc7 version
