### PR TITLE
release nrf 0.21.0

### DIFF
--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -5980,6 +5980,54 @@
               "version": "1.2.1"
             }
           ]
+        },
+        {
+          "name": "Adafruit nRF52",
+          "architecture": "nrf52",
+          "version": "0.21.0",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-nrf52-0.21.0.tar.bz2",
+          "archiveFileName": "adafruit-nrf52-0.21.0.tar.bz2",
+          "checksum": "SHA-256:496db8e54c0ef0334df2b864a3338d7f640823431719dd02e0fa0cd32265ced3",
+          "size": "19180192",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather nRF52832"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Express"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Sense"
+            },
+            {
+              "name": "Adafruit Circuit Playground Bluefruit"
+            },
+            {
+              "name": "Adafruit Metro nRF52840 Express"
+            },
+            {
+              "name": "Adafruit ItsyBitsy nRF52840"
+            },
+            {
+              "name": "Adafruit CLUE"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "adafruit",
+              "name": "arm-none-eabi-gcc",
+              "version": "9-2019q4"
+            },
+            {
+              "packager": "adafruit",
+              "name": "nrfjprog",
+              "version": "9.4.0"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## 0.21.0 - 2020.08.31

Special thanks to @henrygab, @pyro9, @Nenik, @orrmany, @thaanstad, @kevinfrei for contributing and helping with this release.

- Reworked HardwarePWM, analogWrite, Servo, Tone to address PWM hardware conflict with ownership.
- Reworked Tone to use no interrupt handler
- Added multiprotocol support such as ANT with additional ANT_LICENSE_KEY (require 3rd party library)
- Fixed pgm_read_ptr(addr) macro
- Updated & enhanced TinyUSB performance, usb event, task switching is much faster
- Fixed BLE Characteristic discovery when the central device returns more than 4 Characteristics in a discovery request
- Enhanced micro() to use DWT cyclecount if enabled for higher precision
- Fixed miscalculated tick when sleeping with delay()
- Fixed FPU-caused power consumption issue
- Added Wire.setPins()
- Added resumeLoop()
- Renamed I2C terminology
- Support precompiled library with compiler.libraries.ldflags e.g BSEC BME680
- Added Hardware/tone_happy_birthday example sketch
