### PR TITLE
release samd 1.6.6

### DIFF
--- a/bpt.ini
+++ b/bpt.ini
@@ -169,6 +169,9 @@ index_template =
         }},
         {{
            "name":"Adafruit Feather M4 CAN"
+        }},
+        {{
+           "name":"Adafruit Neo Trinkey"
         }}
      ],
      "toolsDependencies": [

--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -6479,6 +6479,124 @@
               "version": "1.2.1"
             }
           ]
+        },
+        {
+          "name": "Adafruit SAMD Boards",
+          "architecture": "samd",
+          "version": "1.6.6",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-samd-1.6.6.tar.bz2",
+          "archiveFileName": "adafruit-samd-1.6.6.tar.bz2",
+          "checksum": "SHA-256:663dd9154376ad6cad7cf9c368cb6235633a2b30c936f4d204a053fb55e53c29",
+          "size": "4753621",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather M0"
+            },
+            {
+              "name": "Adafruit Feather M0 Express"
+            },
+            {
+              "name": "Adafruit Metro M0 Express"
+            },
+            {
+              "name": "Adafruit Circuit Playground Express"
+            },
+            {
+              "name": "Adafruit Gemma M0"
+            },
+            {
+              "name": "Adafruit Trinket M0"
+            },
+            {
+              "name": "Adafruit ItsyBitsy M0"
+            },
+            {
+              "name": "Adafruit pIRkey M0"
+            },
+            {
+              "name": "Adafruit Metro M4"
+            },
+            {
+              "name": "Adafruit Grand Central M4"
+            },
+            {
+              "name": "Adafruit ItsyBitsy M4"
+            },
+            {
+              "name": "Adafruit Feather M4 Express"
+            },
+            {
+              "name": "Adafruit Hallowing M0"
+            },
+            {
+              "name": "Adafruit NeoTrellis M4"
+            },
+            {
+              "name": "Adafruit PyPortal M4"
+            },
+            {
+              "name": "Adafruit PyBadge M4"
+            },
+            {
+              "name": "Adafruit Metro M4 AirLift"
+            },
+            {
+              "name": "Adafruit Matrix Portal M4"
+            },
+            {
+              "name": "Adafruit BLM Badge"
+            },
+            {
+              "name": "Adafruit QT Py"
+            },
+            {
+              "name": "Adafruit Feather M4 CAN"
+            },
+            {
+              "name": "Adafruit Neo Trinkey"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "adafruit",
+              "name": "arm-none-eabi-gcc",
+              "version": "9-2019q4"
+            },
+            {
+              "packager": "arduino",
+              "name": "bossac",
+              "version": "1.7.0-arduino3"
+            },
+            {
+              "packager": "arduino",
+              "name": "bossac",
+              "version": "1.8.0-48-gb176eee"
+            },
+            {
+              "packager": "arduino",
+              "name": "openocd",
+              "version": "0.10.0-arduino7"
+            },
+            {
+              "packager": "adafruit",
+              "name": "CMSIS",
+              "version": "5.4.0"
+            },
+            {
+              "packager": "arduino",
+              "name": "CMSIS-Atmel",
+              "version": "1.2.0"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.2.1"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
add Neo Trinkey board. Note: Neo Trinkey does not have and does not define `LED_BUILTIN` which could cause some of the example/test sketch failed to compile
