### PR TITLE
release samd 1.6.8 for Rotary, NeoKey, Slide, ProxLight Trinkey boards

### DIFF
--- a/bpt.ini
+++ b/bpt.ini
@@ -172,6 +172,18 @@ index_template =
         }},
         {{
            "name":"Adafruit Neo Trinkey"
+        }},
+        {{
+           "name":"Adafruit Rotary Trinkey"
+        }},
+        {{
+           "name":"Adafruit NeoKey Trinkey"
+        }},
+        {{
+           "name":"Adafruit Slide Trinkey"
+        }},
+        {{
+           "name":"Adafruit ProxLight Trinkey"
         }}
      ],
      "toolsDependencies": [

--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -6770,6 +6770,136 @@
               "version": "1.2.1"
             }
           ]
+        },
+        {
+          "name": "Adafruit SAMD Boards",
+          "architecture": "samd",
+          "version": "1.6.8",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-samd-1.6.8.tar.bz2",
+          "archiveFileName": "adafruit-samd-1.6.8.tar.bz2",
+          "checksum": "SHA-256:79d5b8e17016385a77c62edc68fd1a9adbad4b5da8ce0dfb4850e86bac2fa128",
+          "size": "4477494",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather M0"
+            },
+            {
+              "name": "Adafruit Feather M0 Express"
+            },
+            {
+              "name": "Adafruit Metro M0 Express"
+            },
+            {
+              "name": "Adafruit Circuit Playground Express"
+            },
+            {
+              "name": "Adafruit Gemma M0"
+            },
+            {
+              "name": "Adafruit Trinket M0"
+            },
+            {
+              "name": "Adafruit ItsyBitsy M0"
+            },
+            {
+              "name": "Adafruit pIRkey M0"
+            },
+            {
+              "name": "Adafruit Metro M4"
+            },
+            {
+              "name": "Adafruit Grand Central M4"
+            },
+            {
+              "name": "Adafruit ItsyBitsy M4"
+            },
+            {
+              "name": "Adafruit Feather M4 Express"
+            },
+            {
+              "name": "Adafruit Hallowing M0"
+            },
+            {
+              "name": "Adafruit NeoTrellis M4"
+            },
+            {
+              "name": "Adafruit PyPortal M4"
+            },
+            {
+              "name": "Adafruit PyBadge M4"
+            },
+            {
+              "name": "Adafruit Metro M4 AirLift"
+            },
+            {
+              "name": "Adafruit Matrix Portal M4"
+            },
+            {
+              "name": "Adafruit BLM Badge"
+            },
+            {
+              "name": "Adafruit QT Py"
+            },
+            {
+              "name": "Adafruit Feather M4 CAN"
+            },
+            {
+              "name": "Adafruit Neo Trinkey"
+            },
+            {
+              "name": "Adafruit Rotary Trinkey"
+            },
+            {
+              "name": "Adafruit NeoKey Trinkey"
+            },
+            {
+              "name": "Adafruit Slide Trinkey"
+            },
+            {
+              "name": "Adafruit ProxLight Trinkey"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "adafruit",
+              "name": "arm-none-eabi-gcc",
+              "version": "9-2019q4"
+            },
+            {
+              "packager": "arduino",
+              "name": "bossac",
+              "version": "1.7.0-arduino3"
+            },
+            {
+              "packager": "arduino",
+              "name": "bossac",
+              "version": "1.8.0-48-gb176eee"
+            },
+            {
+              "packager": "arduino",
+              "name": "openocd",
+              "version": "0.10.0-arduino7"
+            },
+            {
+              "packager": "adafruit",
+              "name": "CMSIS",
+              "version": "5.4.0"
+            },
+            {
+              "packager": "adafruit",
+              "name": "CMSIS-Atmel",
+              "version": "1.2.1"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.2.1"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
follow up by https://github.com/adafruit/ArduinoCore-samd/pull/296, update release to support new trinkeys