### PR TITLE
release nrf52 0.23.0

### DIFF
--- a/bpt.ini
+++ b/bpt.ini
@@ -315,7 +315,7 @@ index_template =
        {{
          "packager": "adafruit",
          "name": "CMSIS",
-         "version": "5.4.0"
+         "version": "5.7.0"
        }}
      ]
   }}

--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -5,6 +5,61 @@
       "tools": [
         {
           "name": "CMSIS",
+          "version": "5.7.0",
+          "systems": [
+            {
+              "host": "i686-mingw32",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/ARM.CMSIS.5.7.0.zip",
+              "archiveFileName": "ARM.CMSIS.5.7.0.zip",
+              "checksum": "SHA-256:2518a8b66439b0814f27ddda1d38b890d0f601a25778378a6117e7dd393afc44",
+              "size": "117164633"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/ARM.CMSIS.5.7.0.zip",
+              "archiveFileName": "ARM.CMSIS.5.7.0.zip",
+              "checksum": "SHA-256:2518a8b66439b0814f27ddda1d38b890d0f601a25778378a6117e7dd393afc44",
+              "size": "117164633"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/ARM.CMSIS.5.7.0.zip",
+              "archiveFileName": "ARM.CMSIS.5.7.0.zip",
+              "checksum": "SHA-256:2518a8b66439b0814f27ddda1d38b890d0f601a25778378a6117e7dd393afc44",
+              "size": "117164633"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/ARM.CMSIS.5.7.0.zip",
+              "archiveFileName": "ARM.CMSIS.5.7.0.zip",
+              "checksum": "SHA-256:2518a8b66439b0814f27ddda1d38b890d0f601a25778378a6117e7dd393afc44",
+              "size": "117164633"
+            },
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/ARM.CMSIS.5.7.0.zip",
+              "archiveFileName": "ARM.CMSIS.5.7.0.zip",
+              "checksum": "SHA-256:2518a8b66439b0814f27ddda1d38b890d0f601a25778378a6117e7dd393afc44",
+              "size": "117164633"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/ARM.CMSIS.5.7.0.zip",
+              "archiveFileName": "ARM.CMSIS.5.7.0.zip",
+              "checksum": "SHA-256:2518a8b66439b0814f27ddda1d38b890d0f601a25778378a6117e7dd393afc44",
+              "size": "117164633"
+            },
+            {
+              "host": "all",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/ARM.CMSIS.5.7.0.zip",
+              "archiveFileName": "ARM.CMSIS.5.7.0.zip",
+              "checksum": "SHA-256:2518a8b66439b0814f27ddda1d38b890d0f601a25778378a6117e7dd393afc44",
+              "size": "117164633"
+            }
+          ]
+        },
+        {
+          "name": "CMSIS",
           "version": "5.4.0",
           "systems": [
             {
@@ -7444,6 +7499,59 @@
               "packager": "arduino",
               "name": "arduinoOTA",
               "version": "1.2.1"
+            }
+          ]
+        },
+        {
+          "name": "Adafruit nRF52",
+          "architecture": "nrf52",
+          "version": "0.23.0",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-nrf52-0.23.0.tar.bz2",
+          "archiveFileName": "adafruit-nrf52-0.23.0.tar.bz2",
+          "checksum": "SHA-256:52eed7e33271414da848898d487f4ebd5b2b87c275946c57093db864157dbf49",
+          "size": "19546176",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather nRF52832"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Express"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Sense"
+            },
+            {
+              "name": "Adafruit Circuit Playground Bluefruit"
+            },
+            {
+              "name": "Adafruit Metro nRF52840 Express"
+            },
+            {
+              "name": "Adafruit ItsyBitsy nRF52840"
+            },
+            {
+              "name": "Adafruit CLUE"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "adafruit",
+              "name": "arm-none-eabi-gcc",
+              "version": "9-2019q4"
+            },
+            {
+              "packager": "adafruit",
+              "name": "nrfjprog",
+              "version": "9.4.0"
+            },
+            {
+              "packager": "adafruit",
+              "name": "CMSIS",
+              "version": "5.7.0"
             }
           ]
         }


### PR DESCRIPTION
release note for 0.23.0

- Fix CryptoCell usage issue that prevent mcu to go to sleep causing high power consumption
- separate pairing_passkey with and without arcada
- Add back `Raytac MDBT50Q - RX` variant
- Remove Bluefruit.setName() from most examples for it to use default board name
- Update CMSIS from 5.4.0 to 5.7.0
- Fix build with TensorFlowLite v2.4.0
- Update included Adafruit_nRFCrypto to 0.0.5
- Update included Adafruit_TinyUSB_Arduino to 1.1.0
- Update include bootloader binaries to 0.6.0
- Enable usage of DSP libmath
- Added/Ported tf4micro-motion-kit project
- Update BLEUuid
  - Add from string style constructor like ArduinoBLE
  - Add toString() function
- Update BLECharacteristic
  - Add constructor with properties
  - Add constructor with max_len and fixed len
  - Add writeFloat() and readFloat()
