### PR TITLE
release nrf 1.0.0

### DIFF
--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -7916,6 +7916,59 @@
               "version": "1.2.1"
             }
           ]
+        },
+        {
+          "name": "Adafruit nRF52",
+          "architecture": "nrf52",
+          "version": "1.0.0",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-nrf52-1.0.0.tar.bz2",
+          "archiveFileName": "adafruit-nrf52-1.0.0.tar.bz2",
+          "checksum": "SHA-256:798c41111f6f70c008847c5bd89efb1ef6795e07f0c9544b54ebc0739ece26e1",
+          "size": "19410634",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather nRF52832"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Express"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Sense"
+            },
+            {
+              "name": "Adafruit Circuit Playground Bluefruit"
+            },
+            {
+              "name": "Adafruit Metro nRF52840 Express"
+            },
+            {
+              "name": "Adafruit ItsyBitsy nRF52840"
+            },
+            {
+              "name": "Adafruit CLUE"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "adafruit",
+              "name": "arm-none-eabi-gcc",
+              "version": "9-2019q4"
+            },
+            {
+              "packager": "adafruit",
+              "name": "nrfjprog",
+              "version": "9.4.0"
+            },
+            {
+              "packager": "adafruit",
+              "name": "CMSIS",
+              "version": "5.7.0"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Core is stable enough to be released as 1.0.0. Following is chagnes since last release https://github.com/adafruit/Adafruit_nRF52_Arduino/pull/685

- Add UART missing baudrate of 31250 and 56000
- Fix peer bonding with public/static address
- Fix PDM driver issue when BLE is enabled
- Update nrfutil binary to post17 for windows 7
- Add analogSampleTime() to set ADC sample time
- Add readCPUTemperature() to get CPU die temperature
- Add analogCalibrateOffset() to calibrate ADC offset
- Fix UART is not powered down correctly
- Update included bootlaoder binaries to 0.6.1
- Update included TinyUSB lib to 1.4.4