### PR TITLE
change gcc 9-2019 download url from arm to github due to certificate error

### DIFF
--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -236,7 +236,7 @@
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2",
               "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2",
               "checksum": "MD5:0dfa059aae18fcf7d842e30c525076a4",
               "size": "128670769"
@@ -250,14 +250,14 @@
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2",
               "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-mac.tar.bz2",
               "checksum": "MD5:241b64f0578db2cf146034fc5bcee3d4",
               "size": "116770520"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2",
+              "url": "https://github.com/adafruit/arduino-board-index/releases/download/build-tools/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2",
               "archiveFileName": "gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2",
               "checksum": "MD5:fe0029de4f4ec43cf7008944e34ff8cc",
               "size": "116802378"


### PR DESCRIPTION
Somehow gcc toolchain cannot be download from developer.arm.com using wget due to certificate error. This prevent arduino-cli/IDE download the toolchain when installing nrf/samd bsp. This update the tool package to github release page https://github.com/adafruit/arduino-board-index/releases/tag/build-tools . No BSP updated is needed, user only need to fetch the json file.

```
wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
--2021-09-15 23:40:51--  https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
Resolving developer.arm.com (developer.arm.com)... 23.76.74.223
Connecting to developer.arm.com (developer.arm.com)|23.76.74.223|:443... connected.
ERROR: cannot verify developer.arm.com's certificate, issued by 'CN=GlobalSign RSA OV SSL CA 2018,O=GlobalSign nv-sa,C=BE':
  Unable to locally verify the issuer's authority.
To connect to developer.arm.com insecurely, use `--no-check-certificate'.
```

![image](https://user-images.githubusercontent.com/249515/133485892-19c29297-05d3-4643-85c1-408bfe23f92c.png)
