### PR TITLE
Release nrf 1.1.0

### DIFF
--- a/bpt.ini
+++ b/bpt.ini
@@ -299,6 +299,9 @@ index_template =
         }},
         {{
            "name":"Adafruit CLUE"
+        }},
+        {{
+           "name":"Adafruit LED Glasses Driver nRF52840"
         }}
      ],
      "toolsDependencies": [

--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -8099,6 +8099,62 @@
               "version": "1.2.1"
             }
           ]
+        },
+        {
+          "name": "Adafruit nRF52",
+          "architecture": "nrf52",
+          "version": "1.1.0",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-nrf52-1.1.0.tar.bz2",
+          "archiveFileName": "adafruit-nrf52-1.1.0.tar.bz2",
+          "checksum": "SHA-256:8d7adbfe36321ad390d6efbdbdc8aba804f188892372ea9b9ea0dcc0ade23056",
+          "size": "19670237",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather nRF52832"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Express"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Sense"
+            },
+            {
+              "name": "Adafruit Circuit Playground Bluefruit"
+            },
+            {
+              "name": "Adafruit Metro nRF52840 Express"
+            },
+            {
+              "name": "Adafruit ItsyBitsy nRF52840"
+            },
+            {
+              "name": "Adafruit CLUE"
+            },
+            {
+              "name": "Adafruit LED Glasses Driver nRF52840"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "adafruit",
+              "name": "arm-none-eabi-gcc",
+              "version": "9-2019q4"
+            },
+            {
+              "packager": "adafruit",
+              "name": "nrfjprog",
+              "version": "9.4.0"
+            },
+            {
+              "packager": "adafruit",
+              "name": "CMSIS",
+              "version": "5.7.0"
+            }
+          ]
         }
       ]
     },

--- a/trigger_libraries.py
+++ b/trigger_libraries.py
@@ -88,4 +88,7 @@ gh_request = 'curl -X POST -H "Authorization: token {}"'.format(GH_REPO_TOKEN) +
 url = 'https://api.github.com/repos/adafruit/{}/dispatches'
 
 for lib in all_libs:
+    print('Trigger {}'.format(lib))
     subprocess.run(gh_request + url.format(lib), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    # sleep a bit to prevent CI overflow
+    time.sleep(60)


### PR DESCRIPTION
- release nrf 1.1.0 for LED Glasses Driver nRF52840. 
- Also add 1 minutes delay between libraries CI build trigger to reduce CI load.

@ladyada Let me know if new board bsp has any serious issues with pin mapping. we could then postpone this release and correct it first before making the release.