### PR TITLE
Improve monitor esp32

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [pull_request, push]
+on:
+  pull_request:
+    paths: 'package_adafruit_index.json'
+  push:
+    paths: 'package_adafruit_index.json'
 
 jobs:
   build:

--- a/.github/workflows/watch-esp32.yml
+++ b/.github/workflows/watch-esp32.yml
@@ -16,6 +16,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
       run: |
         latest="$(echo `gh release list -R espressif/arduino-esp32 -L 1` | grep -oE 'Latest (.+) ' | cut -d ' ' -f2)"
+        echo "arduino-esp32 latest release is: $latest"
         echo $latest > latest_version.txt
         echo >> $GITHUB_ENV LATEST=$latest
 

--- a/.github/workflows/watch-esp32.yml
+++ b/.github/workflows/watch-esp32.yml
@@ -15,7 +15,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
       run: |
-        latest="$(echo `gh release list -R espressif/arduino-esp32 -L 1` | grep -oE 'Latest (.+) ' | cut -d ' ' -f2)"
+        latest=`gh repo view  espressif/arduino-esp32 --json latestRelease --jq '.latestRelease.tagName'`
         echo "arduino-esp32 latest release is: $latest"
         echo $latest > latest_version.txt
         echo >> $GITHUB_ENV LATEST=$latest


### PR DESCRIPTION
- improve get latest version of arduino-esp32 using json and jq filter (preivously parsing the console output).
- also only run build workflow if `package_adafruit_index.json` file is changed to prevent unnecessary run 