### PR TITLE
release samd 1.7.11

### DIFF
--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -9028,6 +9028,136 @@
               "version": "1.2.1"
             }
           ]
+        },
+        {
+          "name": "Adafruit SAMD Boards",
+          "architecture": "samd",
+          "version": "1.7.11",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-samd-1.7.11.tar.bz2",
+          "archiveFileName": "adafruit-samd-1.7.11.tar.bz2",
+          "checksum": "SHA-256:98a034b25b87bcc8d43ba40686a38b8f98f738a9368087e46d7d4044ce92922d",
+          "size": "4545029",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather M0"
+            },
+            {
+              "name": "Adafruit Feather M0 Express"
+            },
+            {
+              "name": "Adafruit Metro M0 Express"
+            },
+            {
+              "name": "Adafruit Circuit Playground Express"
+            },
+            {
+              "name": "Adafruit Gemma M0"
+            },
+            {
+              "name": "Adafruit Trinket M0"
+            },
+            {
+              "name": "Adafruit ItsyBitsy M0"
+            },
+            {
+              "name": "Adafruit pIRkey M0"
+            },
+            {
+              "name": "Adafruit Metro M4"
+            },
+            {
+              "name": "Adafruit Grand Central M4"
+            },
+            {
+              "name": "Adafruit ItsyBitsy M4"
+            },
+            {
+              "name": "Adafruit Feather M4 Express"
+            },
+            {
+              "name": "Adafruit Hallowing M0"
+            },
+            {
+              "name": "Adafruit NeoTrellis M4"
+            },
+            {
+              "name": "Adafruit PyPortal M4"
+            },
+            {
+              "name": "Adafruit PyBadge M4"
+            },
+            {
+              "name": "Adafruit Metro M4 AirLift"
+            },
+            {
+              "name": "Adafruit Matrix Portal M4"
+            },
+            {
+              "name": "Adafruit BLM Badge"
+            },
+            {
+              "name": "Adafruit QT Py"
+            },
+            {
+              "name": "Adafruit Feather M4 CAN"
+            },
+            {
+              "name": "Adafruit Neo Trinkey"
+            },
+            {
+              "name": "Adafruit Rotary Trinkey"
+            },
+            {
+              "name": "Adafruit NeoKey Trinkey"
+            },
+            {
+              "name": "Adafruit Slide Trinkey"
+            },
+            {
+              "name": "Adafruit ProxLight Trinkey"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "adafruit",
+              "name": "arm-none-eabi-gcc",
+              "version": "9-2019q4"
+            },
+            {
+              "packager": "arduino",
+              "name": "bossac",
+              "version": "1.7.0-arduino3"
+            },
+            {
+              "packager": "adafruit",
+              "name": "bossac",
+              "version": "1.8.0-48-gb176eee"
+            },
+            {
+              "packager": "arduino",
+              "name": "openocd",
+              "version": "0.10.0-arduino7"
+            },
+            {
+              "packager": "adafruit",
+              "name": "CMSIS",
+              "version": "5.4.0"
+            },
+            {
+              "packager": "adafruit",
+              "name": "CMSIS-Atmel",
+              "version": "1.2.2"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.2.1"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
release samd 1.7.11 with removal of ARDUINO_SAMD_ZERO from some boards (qtpy trinket gemma m0). For more changes check out https://github.com/adafruit/ArduinoCore-samd/releases/tag/1.7.11