### PR TITLE
release nrf 1.5.0

### DIFF
--- a/package_adafruit_index.json
+++ b/package_adafruit_index.json
@@ -9474,6 +9474,67 @@
               "version": "1.2.1"
             }
           ]
+        },
+        {
+          "name": "Adafruit nRF52",
+          "architecture": "nrf52",
+          "version": "1.5.0",
+          "category": "Adafruit",
+          "url": "https://adafruit.github.io/arduino-board-index/boards/adafruit-nrf52-1.5.0.tar.bz2",
+          "archiveFileName": "adafruit-nrf52-1.5.0.tar.bz2",
+          "checksum": "SHA-256:2ed5029ba729e6d10b32927aac63b5e82b42138c6886d24004585fedf9808c57",
+          "size": "19747405",
+          "help": {
+            "online": "https://forums.adafruit.com"
+          },
+          "boards": [
+            {
+              "name": "Adafruit Feather nRF52832"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Express"
+            },
+            {
+              "name": "Adafruit Feather nRF52840 Sense"
+            },
+            {
+              "name": "Adafruit Circuit Playground Bluefruit"
+            },
+            {
+              "name": "Adafruit Metro nRF52840 Express"
+            },
+            {
+              "name": "Adafruit ItsyBitsy nRF52840"
+            },
+            {
+              "name": "Adafruit CLUE"
+            },
+            {
+              "name": "Adafruit LED Glasses Driver nRF52840"
+            }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "adafruit",
+              "name": "arm-none-eabi-gcc",
+              "version": "9-2019q4"
+            },
+            {
+              "packager": "adafruit",
+              "name": "nrfjprog",
+              "version": "9.4.0"
+            },
+            {
+              "packager": "adafruit",
+              "name": "CMSIS",
+              "version": "5.7.0"
+            },
+            {
+              "packager": "arduino",
+              "name": "openocd",
+              "version": "0.11.0-arduino2"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
- release nrf 1.5.0 with Arduino IDE v2 debug support with daplink + openocd along with other PRs fixes. Check out https://github.com/adafruit/Adafruit_nRF52_Arduino/releases/tag/1.5.0 for details
